### PR TITLE
add space required by Github version of markdown

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ gitLabel.add(config, labels)
 ```
 
 
-#API
+# API
 
 ### add( config, labels )
 


### PR DESCRIPTION
See https://github.com/matkoniecz/git-label/tree/typo#api - with that space Github considers # as formatting.