### PR TITLE
Feature/label descriptions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,8 +20,8 @@ var config = {
 };
 
 var labels = [
-  { "name": "bug", "color": "#fc2929" },
-  { "name": "duplicate", "color": "#cccccc" }
+  { "name": "bug", "color": "#fc2929", "description": "Something isn't working" },
+  { "name": "duplicate", "color": "#cccccc", "description": "This issue or pull request already exists" }
 ];
 
 // remove specified labels from a repo

--- a/src/lib/label.js
+++ b/src/lib/label.js
@@ -12,13 +12,14 @@ import request from '../lib/request';
  * @param {String} server.repo the git repo to manipulate
  * @param {String} name the name of the label
  * @param {String} color the hexidecimal color of the label
+ * @param {String} description the description of the label
  * @return {Promise}
  */
-export function createLabel({api, token, repo}, name, color) {
+export function createLabel({api, token, repo}, name, color, description) {
   return request({
-    headers: {'User-Agent': 'request', 'Authorization': `token ${token}`},
+    headers: {'User-Agent': 'request', 'Authorization': `token ${token}`, 'Accept': 'text/html, application/vnd.github.symmetra-preview+json'},
     url: `${api}/${repo}/labels`,
-    form: JSON.stringify({name, color}),
+    form: JSON.stringify({name, color, description}),
     method: 'POST',
     json: true
   });
@@ -72,10 +73,11 @@ export function getLabels({api, token, repo}) {
  * @function
  * @param {String} name the name of the label
  * @param {String} color the hexidecimal color of the label
+ * @param {String} description the description of the label
  * @return {Object} a properly formated label object that can be sent to GitHub
  */
-export function formatLabel({name, color}) {
-  return {name, color: color.replace('#', '')};
+export function formatLabel({name, color, description}) {
+  return {name, description, color: color.replace('#', '')};
 }
 
 /**
@@ -94,7 +96,7 @@ export function createLabels(server, labels) {
   return Promise.all(
     labels
     .map(formatLabel)
-    .map(({name, color}) => createLabel(server, name, color))
+    .map(({name, color, description}) => createLabel(server, name, color, description))
   );
 }
 

--- a/test/lib/label.test.js
+++ b/test/lib/label.test.js
@@ -8,8 +8,8 @@ chai.use(chaiAsPromised);
 describe('Lib: Label', () => {
   describe('formatLabel', () => {
     it('should return a properly formatted object', () => {
-      const expected = {name: 'Type: Accepted', color: 'fff' };
-      const actual   = formatLabel({ name: 'Type: Accepted', color: '#fff' });
+      const expected = {name: 'Type: Accepted', color: 'fff', description: 'This is a description' };
+      const actual   = formatLabel({ name: 'Type: Accepted', color: '#fff', description: 'This is a description' });
       return assert.deepEqual(expected, actual);
     });
   })


### PR DESCRIPTION
## Overview
This pr adds support for label descriptions! 🗒 
### Changes
- [x] Add `Accept` header to enable description support
- [x] Add description field to api calls
### Usage
```javascript
var labels = [
  { "name": "bug", "color": "#fc2929", "description": "Something isn't working" },
  { "name": "duplicate", "color": "#cccccc", "description": "This issue or pull request already exists" }
];
```
<img width="636" alt="Screen Shot 2019-06-01 at 10 31 04 PM" src="https://user-images.githubusercontent.com/1305776/58757210-3ab2ea00-84bd-11e9-8a63-729385940af6.png">

(source: [invisiblehats/git-label](https://github.com/invisiblehats/git-label/labels))

I reopened from a previous pr (#22) to clean up the commit history and base it on a non-master branch.

## Issue with encoding?
There's a weird bug where the apostrophe in `isn't` is being formatted wrong. 

The json object from github for the `bug` label looks like this:
```javascript
{ id: 12345678,
  node_id: 'HEX123',
  url: 'https://api.github.com/repos/invisiblehats/class_name/labels/bug',
  name: 'bug',
  color: 'fc2929',
  default: true,
  description: 'Something isn%27t working' }
```

I followed their docs and this is supposed to work. Can someone confirm if they are experiencing the same issue? Github support told me that it should be working (I added the correct headers too)